### PR TITLE
Potential fix for code scanning alert no. 134: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/code-statistics.yml
+++ b/.github/workflows/code-statistics.yml
@@ -1,5 +1,7 @@
 name: Code Statistics
 run-name: Creating code statistics on ${{ github.repository }}
+permissions:
+  contents: read
 on:
   schedule:
     - cron: 30 5 * * 1


### PR DESCRIPTION
Potential fix for [https://github.com/nkalexiou/suricatajs/security/code-scanning/134](https://github.com/nkalexiou/suricatajs/security/code-scanning/134)

To fix the issue, we will add a `permissions` block at the root level of the workflow. Since the workflow only needs to read the repository contents (e.g., to check out the code), we will set `contents: read` as the minimal required permission. This ensures that the `GITHUB_TOKEN` is restricted to read-only access, reducing the risk of unintended write operations.

The changes will be made at the top of the workflow file, immediately after the `name` and `run-name` fields.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
