### PR TITLE
Potential fix for code scanning alert no. 133: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/semgrep-sast.yml
+++ b/.github/workflows/semgrep-sast.yml
@@ -1,5 +1,8 @@
 name: Semgrep-SAST
 
+permissions:
+  contents: read
+
 on:
   workflow_dispatch:
   pull_request:


### PR DESCRIPTION
Potential fix for [https://github.com/nkalexiou/suricatajs/security/code-scanning/133](https://github.com/nkalexiou/suricatajs/security/code-scanning/133)

To fix the issue, we will add a `permissions` block at the workflow level to explicitly define the minimum required permissions. Since the workflow only fetches the repository contents and runs a scan, it likely only needs `contents: read`. This will ensure that the workflow does not inherit unnecessary write permissions from the repository or organization.

The `permissions` block will be added at the root level of the workflow, applying to all jobs within the workflow. This is the simplest and most effective way to address the issue.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
