### PR TITLE
Potential fix for code scanning alert no. 132: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/docker-image-scan.yml
+++ b/.github/workflows/docker-image-scan.yml
@@ -1,4 +1,6 @@
 name: Docker image scanning
+permissions:
+  contents: read
 on:
   workflow_dispatch:
 


### PR DESCRIPTION
Potential fix for [https://github.com/nkalexiou/suricatajs/security/code-scanning/132](https://github.com/nkalexiou/suricatajs/security/code-scanning/132)

To fix the issue, we will add a `permissions` block at the root level of the workflow file. This block will explicitly set the permissions to `contents: read`, which is sufficient for the tasks performed in this workflow. This ensures that the workflow does not inadvertently gain unnecessary write permissions.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
