### PR TITLE
Potential fix for code scanning alert no. 131: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/dynamic-analysis.yml
+++ b/.github/workflows/dynamic-analysis.yml
@@ -1,4 +1,6 @@
 name: Dynamic analysis (DAST)
+permissions:
+  contents: read
 on:
   workflow_dispatch:
 


### PR DESCRIPTION
Potential fix for [https://github.com/nkalexiou/suricatajs/security/code-scanning/131](https://github.com/nkalexiou/suricatajs/security/code-scanning/131)

To fix the issue, we will add a `permissions` block at the root of the workflow file. This block will specify the least privileges required for the workflow to function correctly. Based on the workflow's steps, it primarily requires `contents: read` to check out the code. No other permissions appear necessary, as the workflow does not interact with issues, pull requests, or other repository features.

The `permissions` block will be added after the `name` field and before the `on` field to apply the permissions to all jobs in the workflow.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
