### PR TITLE
ci: suppress semgrep false positives in schema init

### DIFF
--- a/db/database.py
+++ b/db/database.py
@@ -208,7 +208,7 @@ def init_db():
                 date TEXT
             )
         """))
-        conn.execute(text(f"""
+        conn.execute(text(f"""  # nosemgrep: python.sqlalchemy.security.audit.avoid-sqlalchemy-text.avoid-sqlalchemy-text
             CREATE TABLE IF NOT EXISTS alerts (
                 id {pk},
                 javascript TEXT,
@@ -225,7 +225,7 @@ def init_db():
                 source_page TEXT
             )
         """))
-        conn.execute(text(f"""
+        conn.execute(text(f"""  # nosemgrep: python.sqlalchemy.security.audit.avoid-sqlalchemy-text.avoid-sqlalchemy-text
             CREATE TABLE IF NOT EXISTS targets (
                 id {pk},
                 url TEXT NOT NULL UNIQUE,


### PR DESCRIPTION
## Summary

- Add `# nosemgrep` inline suppression to two `CREATE TABLE` f-strings in `db/database.py` (lines 211 and 228)
- Rule fired: `python.sqlalchemy.security.audit.avoid-sqlalchemy-text`
- The `{pk}` variable is a hardcoded internal constant (`INTEGER PRIMARY KEY AUTOINCREMENT` for SQLite, `SERIAL PRIMARY KEY` for PostgreSQL) — it is never derived from user input, so SQL injection is not possible here

## Why suppress rather than refactor

Refactoring would require duplicating two large `CREATE TABLE` blocks (one per DB dialect) for no security benefit. The suppression comment is explicit, scoped to the exact lines, and documents the reasoning.

## Test plan
- [ ] Semgrep CI passes on this PR
- [ ] Existing pytest suite still passes