### PR TITLE
fix: address CodeQL/semgrep security findings

### DIFF
--- a/api/routers/auth.py
+++ b/api/routers/auth.py
@@ -77,9 +77,12 @@ def patch_me(body: PatchMeRequest, current_user: dict = Depends(get_current_user
     if not updates:
         raise HTTPException(status_code=422, detail="Nothing to update")
     with get_connection() as conn:
-        conn.execute(
-            text(f"UPDATE users SET {', '.join(updates)} WHERE id = :id"),
-            params,
-        )
+        if "name" in params and "hash" in params:
+            sql = "UPDATE users SET name = :name, password_hash = :hash WHERE id = :id"
+        elif "name" in params:
+            sql = "UPDATE users SET name = :name WHERE id = :id"
+        else:
+            sql = "UPDATE users SET password_hash = :hash WHERE id = :id"
+        conn.execute(text(sql), params)
     user = _get_user_by_id(current_user["id"])
     return UserResponse(**user)

--- a/api/routers/targets.py
+++ b/api/routers/targets.py
@@ -2,6 +2,7 @@ import datetime
 import json
 import logging
 from typing import List, Optional
+from urllib.parse import urlparse
 
 from fastapi import APIRouter, BackgroundTasks, Depends, HTTPException, Query, Request, Response
 from sqlalchemy import text
@@ -52,6 +53,9 @@ def list_targets(domain_id: Optional[int] = Query(None)):
 
 @router.post("", response_model=TargetResponse, status_code=201)
 def create_target(body: TargetCreate, background_tasks: BackgroundTasks, request: Request):
+    parsed = urlparse(body.url)
+    if parsed.scheme not in ("http", "https"):
+        raise HTTPException(status_code=422, detail="Target URL must use http or https scheme")
     now = datetime.datetime.now().strftime("%Y%m%d_%H%M%S")
     tags_json = json.dumps(body.tags) if body.tags else None
     crawl_depth = body.crawl_depth if body.crawl_depth is not None else 0

--- a/db/database.py
+++ b/db/database.py
@@ -68,7 +68,7 @@ def _migrate_db():
             with engine.begin() as conn:
                 if is_sqlite:
                     conn.execute(text("ALTER TABLE alerts RENAME TO _alerts_pre_v2"))
-                    conn.execute(text(f"""
+                    _v2_alerts_ddl = f"""
                         CREATE TABLE alerts (
                             id {pk},
                             javascript TEXT,
@@ -79,7 +79,8 @@ def _migrate_db():
                             alert_type TEXT,
                             diff TEXT
                         )
-                    """))
+                    """
+                    conn.execute(text(_v2_alerts_ddl))  # nosemgrep: python.sqlalchemy.security.audit.avoid-sqlalchemy-text.avoid-sqlalchemy-text
                     conn.execute(text("""
                         INSERT INTO alerts (javascript, stored_checksum, new_checksum, date, alert_msg, alert_type)
                         SELECT javascript, stored_checksum, new_checksum, date, alert_msg, alert_type
@@ -208,7 +209,8 @@ def init_db():
                 date TEXT
             )
         """))
-        conn.execute(text(f"""  # nosemgrep: python.sqlalchemy.security.audit.avoid-sqlalchemy-text.avoid-sqlalchemy-text
+        # {pk} is a controlled internal constant (SQLite vs Postgres PK syntax), not user input.
+        _alerts_ddl = f"""
             CREATE TABLE IF NOT EXISTS alerts (
                 id {pk},
                 javascript TEXT,
@@ -224,8 +226,9 @@ def init_db():
                 resolved_by INTEGER,
                 source_page TEXT
             )
-        """))
-        conn.execute(text(f"""  # nosemgrep: python.sqlalchemy.security.audit.avoid-sqlalchemy-text.avoid-sqlalchemy-text
+        """
+        conn.execute(text(_alerts_ddl))  # nosemgrep: python.sqlalchemy.security.audit.avoid-sqlalchemy-text.avoid-sqlalchemy-text
+        _targets_ddl = f"""
             CREATE TABLE IF NOT EXISTS targets (
                 id {pk},
                 url TEXT NOT NULL UNIQUE,
@@ -242,8 +245,9 @@ def init_db():
                 domain_id INTEGER,
                 last_scanned_at TEXT
             )
-        """))
-        conn.execute(text(f"""
+        """
+        conn.execute(text(_targets_ddl))  # nosemgrep: python.sqlalchemy.security.audit.avoid-sqlalchemy-text.avoid-sqlalchemy-text
+        _users_ddl = f"""
             CREATE TABLE IF NOT EXISTS users (
                 id {pk},
                 email TEXT NOT NULL UNIQUE,
@@ -252,12 +256,14 @@ def init_db():
                 role TEXT NOT NULL DEFAULT 'operator',
                 created_at TEXT NOT NULL
             )
-        """))
-        conn.execute(text(f"""
+        """
+        conn.execute(text(_users_ddl))  # nosemgrep: python.sqlalchemy.security.audit.avoid-sqlalchemy-text.avoid-sqlalchemy-text
+        _domains_ddl = f"""
             CREATE TABLE IF NOT EXISTS domains (
                 id {pk},
                 domain TEXT NOT NULL UNIQUE,
                 created_at TEXT NOT NULL
             )
-        """))
+        """
+        conn.execute(text(_domains_ddl))  # nosemgrep: python.sqlalchemy.security.audit.avoid-sqlalchemy-text.avoid-sqlalchemy-text
     _bootstrap_admin()


### PR DESCRIPTION
## Summary

Three security findings addressed from static analysis (CodeQL/semgrep) introduced by the v2 UI changes:

### 1. Dynamic SQL in `auth.py` (SQL injection pattern)
`PATCH /auth/me` built the SET clause via `text(f"UPDATE users SET {', '.join(updates)} WHERE id = :id")`. The field names in `updates` were hardcoded literals, so there was no actual injection path — but static analysis cannot prove that. Replaced with explicit `if/elif` branches producing fully literal SQL strings.

### 2. SSRF in `targets.py` (URL scheme validation)
`POST /targets` accepted any URL string and passed it to `requests.get()` in the background scanner. Added scheme validation at the input boundary: only `http` and `https` are accepted. This gates out `file://`, `dict://`, `ftp://`, and other schemes that could be used for SSRF.

### 3. Nosemgrep comment placement in `db/database.py`
Previous suppression comments were placed inside triple-quoted f-strings, which caused SQLite to fail with `unrecognized token: "#"`. Restructured all four DDL blocks to assign the f-string to a local variable, then call `text(variable)  # nosemgrep: ...` on the following line where the comment is valid Python.

## Test plan
- [x] All 139 tests pass locally
- [ ] Semgrep CI passes
- [ ] CodeQL CI passes