### PR TITLE
feat(security): add javascript-typescript to CodeQL Advanced scan

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -53,6 +53,8 @@ jobs:
           build-mode: none
         - language: python
           build-mode: none
+        - language: javascript-typescript
+          build-mode: none
         # CodeQL supports the following values keywords for 'language': 'actions', 'c-cpp', 'csharp', 'go', 'java-kotlin', 'javascript-typescript', 'python', 'ruby', 'rust', 'swift'
         # Use `c-cpp` to analyze code written in C, C++ or both
         # Use 'java-kotlin' to analyze code written in Java, Kotlin or both


### PR DESCRIPTION
## Summary
- Adds `javascript-typescript` to the CodeQL Advanced workflow matrix so JS/TS code is scanned by the custom workflow
- This allows the GitHub Default Setup to be disabled, leaving a single CodeQL scan under version control

## Next step (manual)
After merging, disable the Default Setup in GitHub:
1. **Settings** → **Code Security** → **Code scanning**
2. Next to **Default setup**, click **Edit** → **Disable**

## Test plan
- [ ] Confirm "CodeQL Advanced" action runs three jobs: `actions`, `python`, `javascript-typescript`
- [ ] Confirm findings appear in the Security tab from the Advanced workflow
- [ ] Disable Default Setup and verify only one CodeQL workflow remains

🤖 Generated with [Claude Code](https://claude.com/claude-code)