### PR TITLE
fix(ci): fix CodeQL trigger — remove yml from paths-ignore, add workflow_dispatch

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -17,13 +17,12 @@ on:
     paths-ignore:
       - '**/*.md'
       - '**/*.txt'
-      - '**/*.yml'
   pull_request:
     branches: [ "master" ]
     paths-ignore:
       - '**/*.md'
       - '**/*.txt'
-      - '**/*.yml'
+  workflow_dispatch:
 
 jobs:
   analyze:


### PR DESCRIPTION
## Summary
- Removes `**/*.yml` from `paths-ignore` so workflow file changes trigger a rescan (previously the workflow skipped itself when only `.yml` files changed — a catch-22)
- Adds `workflow_dispatch` trigger so the scan can be run manually from the Actions tab at any time

## Why
The previous PR (#203) added `javascript-typescript` to the matrix but never actually ran because the only changed file was `codeql.yml` itself, which was excluded by `paths-ignore: '**/*.yml'`.

## After merging
1. The workflow will run automatically (triggered by this `.yml` change)
2. You can also trigger it manually: Actions → CodeQL Advanced → Run workflow
3. Once the scan completes, old Default Setup findings in the Security tab will be auto-closed if not reproduced, or confirmed as real issues

🤖 Generated with [Claude Code](https://claude.com/claude-code)