### PR TITLE
fix(security): add URL scheme+netloc validation to clear 6 CodeQL findings

### DIFF
--- a/api/routers/targets.py
+++ b/api/routers/targets.py
@@ -54,7 +54,7 @@ def list_targets(domain_id: Optional[int] = Query(None)):
 @router.post("", response_model=TargetResponse, status_code=201)
 def create_target(body: TargetCreate, background_tasks: BackgroundTasks, request: Request):
     parsed = urlparse(body.url)
-    if parsed.scheme not in ("http", "https"):
+    if parsed.scheme not in ("http", "https") or not parsed.netloc:
         raise HTTPException(status_code=422, detail="Target URL must use http or https scheme")
     now = datetime.datetime.now().strftime("%Y%m%d_%H%M%S")
     tags_json = json.dumps(body.tags) if body.tags else None

--- a/scanner/discovery.py
+++ b/scanner/discovery.py
@@ -25,6 +25,9 @@ def discover_urls(seed_url: str, max_depth: int) -> list:
         visited.add(url)
 
         try:
+            parsed_check = urlparse(url)
+            if parsed_check.scheme not in ("http", "https") or not parsed_check.netloc:
+                continue
             resp = requests.get(url, timeout=15)
             soup = BeautifulSoup(resp.text, features="lxml")
             result.append(url)

--- a/scanner/engine.py
+++ b/scanner/engine.py
@@ -6,7 +6,7 @@ import datetime
 import difflib
 import hashlib
 import logging
-from urllib.parse import urljoin
+from urllib.parse import urljoin, urlparse
 
 import requests
 from bs4 import BeautifulSoup
@@ -20,6 +20,12 @@ from scanner.discovery import discover_urls
 from scanner.playwright_scanner import get_page_scripts
 
 logger = logging.getLogger("suricatajs")
+
+
+def _assert_safe_url(url: str) -> None:
+    parsed = urlparse(url)
+    if parsed.scheme not in ("http", "https") or not parsed.netloc:
+        raise ValueError(f"Refusing to fetch unsafe URL: {url!r}")
 
 
 def _compute_sri(content: str) -> str:
@@ -39,6 +45,7 @@ def _compute_diff(old_js: str, new_js: str) -> str:
 
 def _scan_external_script(script_url: str, page_url: str):
     logger.info(f"Processing {script_url}")
+    _assert_safe_url(script_url)
     jssource = requests.get(script_url, timeout=30).text
     suricata_js = SuricataJSObject(script_url, jssource)
     is_match, stored_checksum = suricata_js.compare_with_db()
@@ -92,6 +99,7 @@ def _scan_inline_script(page_url: str, content: str):
 
 def _scan_page_with_requests(page_url: str):
     try:
+        _assert_safe_url(page_url)
         html_resp = requests.get(page_url, timeout=30).text
         soup = BeautifulSoup(html_resp, features="lxml")
         for script in soup.find_all("script"):

--- a/scanner/playwright_scanner.py
+++ b/scanner/playwright_scanner.py
@@ -1,4 +1,6 @@
 import logging
+from urllib.parse import urlparse
+
 from playwright.sync_api import sync_playwright
 
 logger = logging.getLogger("suricatajs")
@@ -9,6 +11,10 @@ def get_page_scripts(url: str) -> dict:
     Load url in headless Chromium and extract all script src URLs and inline script content.
     Returns {"external": [url, ...], "inline": [content, ...]}.
     """
+    parsed = urlparse(url)
+    if parsed.scheme not in ("http", "https") or not parsed.netloc:
+        raise ValueError(f"Refusing to navigate to unsafe URL: {url!r}")
+
     with sync_playwright() as pw:
         browser = pw.chromium.launch(headless=True)
         try:

--- a/webhooks/delivery.py
+++ b/webhooks/delivery.py
@@ -1,6 +1,7 @@
 import logging
 import os
 import time
+from urllib.parse import urlparse
 
 import requests
 
@@ -13,6 +14,10 @@ def deliver_webhook(payload: dict) -> None:
     """POST payload to WEBHOOK_URL. Retries up to 3 times with exponential backoff. No-ops if WEBHOOK_URL is unset."""
     url = os.getenv("WEBHOOK_URL", "").strip()
     if not url:
+        return
+    parsed = urlparse(url)
+    if parsed.scheme not in ("http", "https") or not parsed.netloc:
+        logger.error("WEBHOOK_URL is not a valid http/https URL — skipping delivery")
         return
 
     for attempt in range(_MAX_ATTEMPTS):


### PR DESCRIPTION
## Summary
Fixes 6 CodeQL `py/ssrf` / `py/incomplete-url-scheme-check` findings by adding explicit URL validation at every point where a URL is used in an outbound HTTP request or browser navigation.

**Root cause:** CodeQL's data-flow analysis does not treat the database as a trust boundary. Even though `targets.py` validates URLs at the API layer, the downstream fetch calls in the scanner looked unguarded to CodeQL.

## Changes

| File | Change |
|---|---|
| `api/routers/targets.py` | Added `netloc` check to existing scheme validation — rejects `http://` (empty host) |
| `scanner/engine.py` | Added `_assert_safe_url()` helper; called before `requests.get()` in `_scan_external_script` and `_scan_page_with_requests` |
| `scanner/discovery.py` | Added inline scheme+netloc guard before `requests.get()` in the BFS crawler |
| `scanner/playwright_scanner.py` | Added scheme+netloc guard before `page.goto()` |
| `webhooks/delivery.py` | Validates `WEBHOOK_URL` env var before `requests.post()` |

## Test plan
- [x] `pytest tests/ -q` — 139 passed, 13 skipped, 0 failures
- [ ] After merge: CodeQL Advanced scan runs automatically and the 6 Security tab findings auto-close

🤖 Generated with [Claude Code](https://claude.com/claude-code)